### PR TITLE
fix: pass full service account credentials to GoogleAuth

### DIFF
--- a/src/lib/google-play/client.ts
+++ b/src/lib/google-play/client.ts
@@ -19,10 +19,7 @@ export function createGooglePlayClient(credentials: ServiceAccountCredentials): 
   }
 
   const auth = new GoogleAuth({
-    credentials: {
-      client_email: credentials.client_email,
-      private_key: credentials.private_key,
-    },
+    credentials: credentials,
     scopes: ['https://www.googleapis.com/auth/androidpublisher'],
   });
 


### PR DESCRIPTION
GoogleAuth.fromJSON() in google-auth-library v10 requires the complete service account JSON object (including type, private_key_id, project_id) to properly initialize a JWT client. Passing only client_email and private_key caused authentication to fail with "Invalid credentials".